### PR TITLE
Add Kurdish and Arabic to Phone System

### DIFF
--- a/src/api/helpers.js
+++ b/src/api/helpers.js
@@ -8,11 +8,15 @@ import axios from 'axios';
 export const LANGUAGE = {
   en_US: 'en-US',
   es_MX: 'es-MX',
+  ar: 'ar',
+  ku: 'ku',
 };
 
 const LANGUAGE_IDS = {
   en_US: 2,
   es_MX: 7,
+  ar: 11,
+  ku: 230,
 };
 
 export const getLanguageId = async (subtag) => {

--- a/src/index.js
+++ b/src/index.js
@@ -224,6 +224,8 @@ export const contactStreamHandler = async (event, context) => {
   const queueCounts = {
     [LANGUAGE.en_US]: 0,
     [LANGUAGE.es_MX]: 0,
+    [LANGUAGE.ar]: 0,
+    [LANGUAGE.ku]: 0,
   };
   Records.forEach(({ eventName, dynamodb: { NewImage, OldImage } }) => {
     let contactLocale = LANGUAGE.en_US;


### PR DESCRIPTION
Braden, we need to allow users to select Arabic and Kurdish phone calls.
Add Arabic and Kurdish to https://www.crisiscleanup.org/profile, https://www.crisiscleanup.org/phone (edit) (..phone\CallerIDEditCard.vue), and prioritize routing calls to Arabic and Kurdish speakers just like we do for Spanish.

This is me messing with a few of the obvious places that needs to happen, with no real understanding of what's going on.